### PR TITLE
Fix access control of the initializer.

### DIFF
--- a/Sources/Ricemill/Machine.swift
+++ b/Sources/Ricemill/Machine.swift
@@ -51,11 +51,11 @@ open class Machine<Resolver: ResolverType> {
     private let _store: Resolver.Store
     private let _cancellables: [AnyCancellable]
 
-    private init(input: Resolver.Input,
-                 output: Resolver.Output,
-                 store: Resolver.Store,
-                 extra: Resolver.Extra,
-                 cancellables: [AnyCancellable]) {
+    public init(input: Resolver.Input,
+                output: Resolver.Output,
+                store: Resolver.Store,
+                extra: Resolver.Extra,
+                cancellables: [AnyCancellable]) {
         self.input = InputProxy(input)
         self.output = OutputProxy(output)
         self._store = store


### PR DESCRIPTION
Hi, marty-suzuki.
Thank you for the cool framework!

Fixed access control for designated initializer to make the convenience initializer work.

<Info.>
I installed it on my iOS project via the SwiftPM.
I'm using Xcode 12.3.

<Problem.>
<img width="500" alt="img" src="https://user-images.githubusercontent.com/25205138/106371750-82cd9280-63ab-11eb-9ba6-b19284968e2f.png">

Best regards,